### PR TITLE
update package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test-debug": "npm build && node --inspect --debug-brk ./node_modules/.bin/jasmine JASMINE_CONFIG_PATH=test/jasmine.json"
   },
   "devDependencies": {
-    "babel-eslint": "^8.2.1",
+    "babel-eslint": "^8.2.6",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
@@ -40,26 +40,26 @@
     "babel-preset-flow-vue": "^1.0.0",
     "babel-register": "^6.24.1",
     "buble": "^0.18.0",
-    "cross-env": "^5.1.3",
-    "eslint": "^4.16.0",
+    "cross-env": "^5.2.1",
+    "eslint": "^4.19.1",
     "eslint-config-vue": "^2.0.2",
-    "eslint-plugin-flowtype": "^2.30.4",
-    "eslint-plugin-jasmine": "^2.2.0",
-    "eslint-plugin-vue": "^4.2.0",
+    "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-jasmine": "^2.10.1",
+    "eslint-plugin-vue": "^4.7.1",
     "flow": "^0.2.3",
-    "jasmine": "^2.5.3",
-    "rollup": "^0.55.0",
-    "rollup-plugin-alias": "^1.2.1",
+    "jasmine": "^2.99.0",
+    "rollup": "^0.55.5",
+    "rollup-plugin-alias": "^1.5.2",
     "rollup-plugin-buble": "^0.18.0",
     "rollup-plugin-flow-no-whitespace": "^1.0.0",
-    "rollup-plugin-node-resolve": "^3.0.2",
-    "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-replace": "^2.2.0",
     "rollup-watch": "^4.3.1",
-    "vue": "^2.5.13"
+    "vue": "^2.6.10"
   },
   "dependencies": {
     "blessed": "^0.1.81",
-    "blessed-contrib": "^4.8.5",
-    "lodash": "^4.17.4"
+    "blessed-contrib": "^4.8.16",
+    "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
your code is pretty good and works with the newer package deps

The only thing found for the build is some warning of `circular dependancy` of VueJS 2.6

```
/private/tmp/blessed-vue/src/index.js → dist/build.js...
(!) Circular dependency: node_modules/vue/src/core/util/index.js -> node_modules/vue/src/core/util/options.js -> node_modules/vue/src/core/observer/index.js -> node_modules/vue/src/core/observer/dep.js -> node_modules/vue/src/core/util/index.js
(!) Circular dependency: node_modules/vue/src/core/util/index.js -> node_modules/vue/src/core/util/options.js -> node_modules/vue/src/core/observer/index.js -> node_modules/vue/src/core/observer/array.js -> node_modules/vue/src/core/util/index.js
(!) Circular dependency: node_modules/vue/src/core/util/index.js -> node_modules/vue/src/core/util/options.js -> node_modules/vue/src/core/observer/index.js -> node_modules/vue/src/core/util/index.js
(!) Circular dependency: node_modules/vue/src/core/observer/watcher.js -> node_modules/vue/src/core/observer/scheduler.js -> node_modules/vue/src/core/instance/lifecycle.js -> node_modules/vue/src/core/observer/watcher.js
```

would you like to give it a update?